### PR TITLE
按需引入@icon-park/svg字体，减少prebundle体积

### DIFF
--- a/packages/core/src/ejs/icon.taro.ejs
+++ b/packages/core/src/ejs/icon.taro.ejs
@@ -1,5 +1,5 @@
 import React from 'react'
-import { <%= icon.name %> as originIcon } from '@icon-park/svg'
+import originIcon from '@icon-park/svg/es/icons/<%= icon.name %>'
 import { IIconProps } from '@icon-park/svg/lib/runtime'
 import svg64 from 'svg64'
 


### PR DESCRIPTION
Taro 3.5开始支持prebundle，默认情况下直接 import @icon-park/svg，那么小程序预览时的体积会增加4m+，直接导致开发阶段不可能进行预览了。 改成只引入指定的icon后，可以大大降低prebundle时的开销。